### PR TITLE
Update cloning.md

### DIFF
--- a/docs/workshop/content/cloning.md
+++ b/docs/workshop/content/cloning.md
@@ -1,23 +1,23 @@
-In this lab we're going to clone a workload and prove that it's identical to the previous. For convenience we're going to download and customise a Fedora 31 image, launch a virtual machine via OpenShift virtualisation based on it, and then clone it - we'll then test to see if the cloned machine works as expected. Before we begin we need to setup our Fedora 31 cloud image, let's first connect to our bastion host as we need somewhere to process and serve the image:
+In this lab we're going to clone a workload and prove that it's identical to the previous. For convenience we're going to download and customise a Fedora 33 image, launch a virtual machine via OpenShift virtualisation based on it, and then clone it - we'll then test to see if the cloned machine works as expected. Before we begin we need to setup our Fedora 33 cloud image, let's first connect to our bastion host as we need somewhere to process and serve the image:
 
 ~~~bash
 $ ssh root@ocp4-bastion
 (password is "redhat")
 ~~~
 
-Change directory to `/var/www/html` and download the latest Fedora 31 cloud image there:
+Change directory to `/var/www/html` and download the latest Fedora 33 cloud image there:
 
 ~~~bash
 # cd /var/www/html
 
-# wget https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.raw.xz
+# wget --no-dns-cache  https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.raw.xz
 (...)
 
-# xz -d Fedora-Cloud-Base-31-1.9.x86_64.raw.xz
+# xz -d Fedora-Cloud-Base-33-1.2.x86_64.raw.xz
 (no output but may take a minute)
 
 # ls -l | grep -i fedora
--rw-r--r--. 1 root root  4294967296 Oct 23 19:07 Fedora-Cloud-Base-31-1.9.x86_64.raw
+-rw-r--r--. 1 root root  4294967296 Oct 23 19:07 Fedora-Cloud-Base-33-1.2.x86_64.raw
 ~~~
 
 Now we need to customise this image, we're going to do the following:
@@ -31,12 +31,12 @@ Now we need to customise this image, we're going to do the following:
 
 # systemctl enable --now libvirtd
 
-# virt-customize -a /var/www/html/Fedora-Cloud-Base-31-1.9.x86_64.raw --run-command 'sed -i s/^#PermitRootLogin.*/PermitRootLogin\ yes/ /etc/ssh/sshd_config'
+# virt-customize -a /var/www/html/Fedora-Cloud-Base-33-1.2.x86_64.raw --run-command 'sed -i s/^#PermitRootLogin.*/PermitRootLogin\ yes/ /etc/ssh/sshd_config'
 
 [   0.0] Examining the guest ...
 (...)
 
-# virt-customize -a /var/www/html/Fedora-Cloud-Base-31-1.9.x86_64.raw --uninstall=cloud-init --root-password password:redhat --ssh-inject root:file:/root/.ssh/id_rsa.pub
+# virt-customize -a /var/www/html/Fedora-Cloud-Base-33-1.2.x86_64.raw --uninstall=cloud-init --root-password password:redhat --ssh-inject root:file:/root/.ssh/id_rsa.pub
 
 [   0.0] Examining the guest ...
 (...)
@@ -48,7 +48,7 @@ Connection to ocp4-bastion closed.
 
 > **NOTE**: Make sure that you've disconnected from this machine before proceeding.
 
-Now that we've prepared our Fedora 31 VM and placed it on an accessible location on our bastion host: (for reference it's at: http://192.168.123.100:81/Fedora-Cloud-Base-31-1.9.x86_64.raw). 
+Now that we've prepared our Fedora 33 VM and placed it on an accessible location on our bastion host: (for reference it's at: http://192.168.123.100:81/Fedora-Cloud-Base-33-1.2.x86_64.raw). 
 
 Let's build a PV that will eventually house a copy of this image so we can build a VM from it afterwards:
 
@@ -57,7 +57,7 @@ $ cat << EOF | oc apply -f -
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: fc31-pv
+  name: fc33-pv
 spec:
   accessModes:
   - ReadWriteOnce
@@ -65,23 +65,23 @@ spec:
   capacity:
     storage: 10Gi
   nfs:
-    path: /nfs/fc31
+    path: /nfs/fc33
     server: 192.168.123.100
   persistentVolumeReclaimPolicy: Delete
   storageClassName: nfs
   volumeMode: Filesystem
 EOF
 
-persistentvolume/fc31-pv created
+persistentvolume/fc33-pv created
 ~~~
 
 And make sure the volume is `Available`:
 
 ~~~bash
- $ oc get pv/fc31-pv
+ $ oc get pv/fc33-pv
 NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM
                       STORAGECLASS           REASON   AGE
-fc31-pv                                    10Gi       RWO,RWX        Delete           Available
+fc33-pv                                    10Gi       RWO,RWX        Delete           Available
                       nfs                             20s
 ~~~
 
@@ -92,11 +92,11 @@ $ cat << EOF | oc apply -f -
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: "fc31-nfs"
+  name: "fc33-nfs"
   labels:
     app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "http://192.168.123.100:81/Fedora-Cloud-Base-31-1.9.x86_64.raw"
+    cdi.kubevirt.io/storage.import.endpoint: "http://192.168.123.100:81/Fedora-Cloud-Base-33-1.2.x86_64.raw"
 spec:
   volumeMode: Filesystem
   storageClassName: nfs
@@ -113,15 +113,15 @@ persistentvolumeclaim/fc31-nfs created
 As before we can watch the process and see the pods (you'll need to be quick with the next two commands, as it's only a 10GB image):
 
 ~~~bash
-$ oc get pod/importer-fc31-nfs
+$ oc get pod/importer-fc33-nfs
 NAME                                        READY   STATUS    RESTARTS   AGE
-importer-fc31-nfs                           1/1     Running   0          5s
+importer-fc33-nfs                           1/1     Running   0          5s
 ~~~
 
 The import:
 
 ~~~bash
-$ oc logs importer-fc31-nfs -f
+$ oc logs importer-fc33-nfs -f
 I0319 02:41:06.647561       1 importer.go:51] Starting importer
 I0319 02:41:06.651389       1 importer.go:107] begin import process
 I0319 02:41:06.654768       1 data-processor.go:275] Calculating available size
@@ -139,21 +139,21 @@ A stripped down importer description, noting that it's unlikely that you'll be a
 
 ~~~bash
 $ oc describe pod $(oc get pods | awk '/importer/ {print $1;}')
-Name:         importer-fc31-nfs
+Name:         importer-fc33-nfs
 Namespace:    default
 Priority:     0
 Node:         ocp4-worker2.cnv.example.com/192.168.123.105
 Start Time:   Thu, 19 Mar 2020 02:41:03 +0000
 Labels:       app=containerized-data-importer
               cdi.kubevirt.io=importer
-              cdi.kubevirt.io/storage.import.importPvcName=fc31-nfs
+              cdi.kubevirt.io/storage.import.importPvcName=fc33-nfs
               prometheus.cdi.kubevirt.io=
 Annotations:  cdi.kubevirt.io/storage.createdByController: yes
               k8s.v1.cni.cncf.io/networks-status:
 (...)
     Environment:
       IMPORTER_SOURCE:       http
-      IMPORTER_ENDPOINT:     http://192.168.123.100:81/Fedora-Cloud-Base-31-1.9.x86_64.raw
+      IMPORTER_ENDPOINT:     http://192.168.123.100:81/Fedora-Cloud-Base-33-1.2.x86_64.raw
       IMPORTER_CONTENTTYPE:  kubevirt
       IMPORTER_IMAGE_SIZE:   10Gi
       OWNER_UID:             6cf06f28-7056-40e8-bb8b-2bac5abbe363
@@ -165,7 +165,7 @@ Annotations:  cdi.kubevirt.io/storage.createdByController: yes
 Volumes:
   cdi-data-vol:
     Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
-    ClaimName:  fc31-nfs
+    ClaimName:  fc33-nfs
     ReadOnly:   false
 (...)
 ~~~
@@ -173,25 +173,25 @@ Volumes:
 And finally our working PVC:
 
 ~~~bash
-$ oc get pvc/fc31-nfs
+$ oc get pvc/fc33-nfs
 NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
-fc31-nfs         Bound    fc31-pv                                    10Gi       RWO,RWX        nfs                    2m13s
+fc31-nfs         Bound    fc33-pv                                    10Gi       RWO,RWX        nfs                    2m13s
 ~~~
 
 
 
-### Fedora 31 Virtual Machine
+### Fedora 33 Virtual Machine
 
-Now it's time to launch our Fedora VM. Again we are just using the same pieces we've been using throughout the labs. For review we are using the `fc31-nfs` PVC we just prepared (created with CDI importing the Fedora image, stored on NFS), and we are utilising the standard bridged networking on the workers via the `tuning-bridge-fixed` construct - the same as we've been using for the other two virtual machines:
+Now it's time to launch our Fedora VM. Again we are just using the same pieces we've been using throughout the labs. For review we are using the `fc33-nfs` PVC we just prepared (created with CDI importing the Fedora image, stored on NFS), and we are utilising the standard bridged networking on the workers via the `tuning-bridge-fixed` construct - the same as we've been using for the other two virtual machines:
 
 ~~~bash
 $ cat << EOF | oc apply -f -
 apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachine
 metadata:
-  name: fc31-nfs
+  name: fc33-nfs
   labels:
-    app: fc31-nfs
+    app: fc33-nfs
     flavor.template.kubevirt.io/small: 'true'
     os.template.kubevirt.io/fedora31: 'true'
     vm.kubevirt.io/template: fedora-server-small-v0.11.3
@@ -205,7 +205,7 @@ spec:
         flavor.template.kubevirt.io/small: 'true'
         kubevirt.io/size: small
         os.template.kubevirt.io/fedora31: 'true'
-        vm.kubevirt.io/name: fc31-nfs
+        vm.kubevirt.io/name: fc33-nfs
         workload.template.kubevirt.io/server: 'true'
     spec:
       domain:
@@ -241,21 +241,21 @@ spec:
       volumes:
         - name: disk0
           persistentVolumeClaim:
-            claimName: fc31-nfs
+            claimName: fc33-nfs
 EOF
 
-virtualmachine.kubevirt.io/fc31-nfs created    
+virtualmachine.kubevirt.io/fc33-nfs created    
 ~~~
 
 We can view the running VM:
 
 ~~~bash
- $ oc get vmi/fc31-nfs
+ $ oc get vmi/fc33-nfs
 NAME                    AGE     PHASE     IP                  NODENAME
-fc31-nfs                28m     Running                       ocp4-worker2.cnv.example.com
+fc33-nfs                28m     Running                       ocp4-worker2.cnv.example.com
 ~~~
 
-> **NOTE:** The IP address for the Fedora 31 virtual machine will be missing as the `qemu-guest-agent` isn't installed by default, but it should still have networking access. We'll need to utilise the console to get these next steps finalised.
+> **NOTE:** The IP address for the Fedora 33 virtual machine will be missing as the `qemu-guest-agent` isn't installed by default, but it should still have networking access. We'll need to utilise the console to get these next steps finalised.
 
 Navigate to the OpenShift UI so we can access the console of the `fc31-nfs` virtual machine. You'll need to select "**Workloads**" --> "**Virtual Machines**" --> "**fc31-nfs**" --> "**Consoles**". You'll be able to login with "**root/redhat**", noting that you may have to click on the console window for it to capture your input. Tip: You might find `Serial Console` option is more responsive.
 
@@ -294,12 +294,12 @@ And then exit the shell:
 [root@localhost ~]# logout
 ~~~
 
-Now if we return to our lab terminal we should be able to see the IP address of the Fedora 31 machine via the OpenShift API; if so, let's try ssh'ing to it:
+Now if we return to our lab terminal we should be able to see the IP address of the Fedora 33 machine via the OpenShift API; if so, let's try ssh'ing to it:
 
 ~~~bash
 $ oc get vmi/fc31-nfs
 NAME       AGE   PHASE     IP                  NODENAME
-fc31-nfs   24m   Running   192.168.123.64/24   ocp4-worker1.cnv.example.com
+fc33-nfs   24m   Running   192.168.123.64/24   ocp4-worker1.cnv.example.com
 
 $ ssh root@192.168.123.64
 (the password is "redhat")
@@ -355,7 +355,7 @@ $
 
 Let's quickly verify that this works as expected - you should be able to navigate directly to the IP address of your machine in your browser - recalling that in my example it's *192.168.123.64*, it may be different for you, but unlikely if you've not created any additional VM's along the way:
 
-<img src="img/nginx-fc31.png"/>
+<img src="img/nginx-fc33.png"/>
 
 > **NOTE**: These steps are important for both this lab and a future one; please ensure they complete correctly.
 
@@ -375,12 +375,12 @@ virtualmachine.kubevirt.io/fc31-nfs edited
 > **NOTE**: You can prefix the `oc edit` command with "`EDITOR=<your favourite editor>`" if you'd prefer to use something other than vi to do this work. Also note that "ReRunOnFailure" simply means that OpenShift virtualisation will do its best to automatically restart this VM if a failure has occurred, but won't always enforce it to be running, e.g. if the user shuts it down
 
 
-Now reopen the  ssh-session to the Fedora 31 machine and power it off:
+Now reopen the  ssh-session to the Fedora 33 machine and power it off:
 
 ~~~bash
-$ oc get vmi/fc31-nfs
+$ oc get vmi/fc33-nfs
 NAME       AGE   PHASE     IP                  NODENAME
-fc31-nfs   18m   Running   192.168.123.64/24   ocp4-worker1.cnv.example.com
+fc33-nfs   18m   Running   192.168.123.64/24   ocp4-worker1.cnv.example.com
 
 $ ssh root@192.168.123.64
 (password is "redhat")
@@ -395,7 +395,7 @@ Now if you check the list of `vmi` objects you should see that it's marked as `S
 ~~~bash
 $ oc get vmi
 NAME                    AGE   PHASE       IP                  NODENAME
-fc31-nfs                19m   Succeeded   192.168.123.65/24   ocp4-worker1.cnv.example.com
+fc33-nfs                19m   Succeeded   192.168.123.65/24   ocp4-worker1.cnv.example.com
 rhel8-server-hostpath   91m   Running     192.168.123.63/24   ocp4-worker1.cnv.example.com
 rhel8-server-nfs        94m   Running     192.168.123.62/24   ocp4-worker1.cnv.example.com
 ~~~
@@ -406,19 +406,19 @@ rhel8-server-nfs        94m   Running     192.168.123.62/24   ocp4-worker1.cnv.e
 
 Now that we've got a working virtual machine with a test workload we're ready to actually clone it, to prove that the built-in cloning utilities work, and that the cloned machine shares the same workload. First we need to create a PV (persistent volume) to clone into. This is done by creating a special resource called a `DataVolume`, this custom resource type is provide by CDI. DataVolumes orchestrate import, clone, and upload operations and help the process of importing data into a cluster. DataVolumes are integrated into OpenShift virtualisation.
 
-The volume we are creating is named `fc31-clone`, we'll be pulling the data from the volume ("source") `fc31-nfs` and we'll tell the CDI to provision onto a specific node. We're only using this option to demonstrate the annotation, but also because we're going to clone from an NFS-based volume onto a hostpath based volume; this is important because hostpath volumes are not shared-storage based, so the location you specify here is important as that's exactly where the cloned VM will have to run:
+The volume we are creating is named `fc33-clone`, we'll be pulling the data from the volume ("source") `fc33-nfs` and we'll tell the CDI to provision onto a specific node. We're only using this option to demonstrate the annotation, but also because we're going to clone from an NFS-based volume onto a hostpath based volume; this is important because hostpath volumes are not shared-storage based, so the location you specify here is important as that's exactly where the cloned VM will have to run:
 
 ~~~bash
 $ cat << EOF | oc apply -f -
 apiVersion: cdi.kubevirt.io/v1alpha1
 kind: DataVolume
 metadata:
-  name: fc31-clone
+  name: fc33-clone
 spec:
   source:
     pvc:
       namespace: default
-      name: fc31-nfs
+      name: fc33-nfs
   pvc:
     accessModes:
       - ReadWriteOnce
@@ -428,7 +428,7 @@ spec:
         storage: 20Gi
 EOF
 
-datavolume.cdi.kubevirt.io/fc31-clone created
+datavolume.cdi.kubevirt.io/fc33-clone created
 ~~~
 
 You can watch the progress with where it will go through `CloneScheduled` and `CloneInProgress` phases along with a handy status precentage:
@@ -438,15 +438,15 @@ $ watch -n5 oc get datavolume
 Every 5.0s: oc get datavolume
 
 NAME         PHASE            PROGRESS   AGE
-fc31-clone   CloneScheduled              39s
+fc33-clone   CloneScheduled              39s
 (...)
 
 NAME         PHASE             PROGRESS   AGE
-fc31-clone   CloneInProgress   27.38%     2m46s
+fc33-clone   CloneInProgress   27.38%     2m46s
 (...)
 
 NAME         PHASE       PROGRESS   AGE
-fc31-clone   Succeeded   100.0%     3m13s
+fc33-clone   Succeeded   100.0%     3m13s
 
 (Ctrl-C to stop/quit)
 ~~~
@@ -460,8 +460,8 @@ View all your PVCs, and the new clone:
 ~~~bash
 $ oc get pvc
 NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS           AGE
-fc31-clone       Bound    pvc-64de80bd-0805-45bc-81d3-56482e609705   79Gi       RWO            hostpath-provisioner   5m10s
-fc31-nfs         Bound    fc31-pv                                    10Gi       RWO,RWX        nfs                    75m
+fc33-clone       Bound    pvc-64de80bd-0805-45bc-81d3-56482e609705   79Gi       RWO            hostpath-provisioner   5m10s
+fc33-nfs         Bound    fc31-pv                                    10Gi       RWO,RWX        nfs                    75m
 rhel8-hostpath   Bound    pvc-6f7eb369-6605-486c-93b9-07d8069aad34   79Gi       RWO            hostpath-provisioner   106m
 rhel8-nfs        Bound    nfs-pv1                                    40Gi       RWO,RWX        nfs                    120m11
 ~~~
@@ -477,9 +477,9 @@ $ cat << EOF | oc apply -f -
 apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachine
 metadata:
-  name: fc31-clone
+  name: fc33-clone
   labels:
-    app: fc31-clone
+    app: fc33-clone
     flavor.template.kubevirt.io/small: 'true'
     os.template.kubevirt.io/fedora31: 'true'
     vm.kubevirt.io/template: fedora-server-small-v0.11.3
@@ -492,8 +492,8 @@ spec:
       labels:
         flavor.template.kubevirt.io/small: 'true'
         kubevirt.io/size: small
-        os.template.kubevirt.io/fedora31: 'true'
-        vm.kubevirt.io/name: fc31-clone
+        os.template.kubevirt.io/fedora33: 'true'
+        vm.kubevirt.io/name: fc33-clone
         workload.template.kubevirt.io/server: 'true'
     spec:
       domain:
@@ -520,7 +520,7 @@ spec:
           requests:
             memory: 2Gi
       evictionStrategy: LiveMigrate
-      hostname: fc31-clone
+      hostname: fc33-clone
       networks:
         - multus:
             networkName: tuning-bridge-fixed
@@ -529,10 +529,10 @@ spec:
       volumes:
         - name: disk0
           persistentVolumeClaim:
-            claimName: fc31-clone
+            claimName: fc33-clone
 EOF
 
-virtualmachine.kubevirt.io/fc31-clone created
+virtualmachine.kubevirt.io/fc33-clone created
 ~~~
 
 After a few minutes you should see the new virtual machine running:
@@ -540,8 +540,8 @@ After a few minutes you should see the new virtual machine running:
 ~~~bash
 $ oc get vmi
 NAME                    AGE     PHASE       IP                  NODENAME
-fc31-clone              6m15s   Running     192.168.123.67/24   ocp4-worker2.cnv.example.com
-fc31-nfs                37m     Succeeded   192.168.123.64/24   ocp4-worker1.cnv.example.com
+fc33-clone              6m15s   Running     192.168.123.67/24   ocp4-worker2.cnv.example.com
+fc33-nfs                37m     Succeeded   192.168.123.64/24   ocp4-worker1.cnv.example.com
 rhel8-server-hostpath   109m    Running     192.168.123.63/24   ocp4-worker1.cnv.example.com
 rhel8-server-nfs        111m    Running     192.168.123.62/24   ocp4-worker1.cnv.example.com
 ~~~
@@ -550,7 +550,7 @@ rhel8-server-nfs        111m    Running     192.168.123.62/24   ocp4-worker1.cnv
 
 This machine will also be visible from the console, and you can login using "**root/redhat**" just like before:
 
-<img src="img/fc31-clone-console.png"/>
+<img src="img/fc33-clone-console.png"/>
 
 ### Test the clone
 
@@ -567,9 +567,9 @@ That's it! You've proven that your clone has worked, and that the hostpath based
 Before moving on to the next lab let's clean up the VMs so we ensure our environment has all the resources it might need; we're going to delete our Fedora VMs and our RHEL8 hostpath VM:
 
 ~~~bash
-$ oc delete vm/fc31-clone vm/fc31-nfs vm/rhel8-server-hostpath
-virtualmachine.kubevirt.io "fc31-clone" deleted
-virtualmachine.kubevirt.io "fc31-nfs" deleted
+$ oc delete vm/fc31-clone vm/fc33-nfs vm/rhel8-server-hostpath
+virtualmachine.kubevirt.io "fc33-clone" deleted
+virtualmachine.kubevirt.io "fc33-nfs" deleted
 virtualmachine.kubevirt.io "rhel8-server-hostpath" deleted
 ~~~
 


### PR DESCRIPTION
- Updated the image for using the Fedora-Cloud-Base-33-1.2.x86_64.raw.xz since the image https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.raw.xz is not available more or at least it's returning an HTTP response code 404:

~~~
# wget https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.raw.xz
--2021-01-26 08:42:31--  https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.raw.xz
Resolving download.fedoraproject.org (download.fedoraproject.org)... 140.211.169.196, 152.19.134.142, 8.43.85.67, ...
Connecting to download.fedoraproject.org (download.fedoraproject.org)|140.211.169.196|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-01-26 08:42:32 ERROR 404: Not Found.
~~~

At the same time, the wget command could return the error below:

~~~
# wget https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.raw.xz
--2021-01-26 08:48:01--  https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.raw.xz
Resolving download.fedoraproject.org (download.fedoraproject.org)... 8.43.85.73, 209.132.190.2, 152.19.134.198, ...
Connecting to download.fedoraproject.org (download.fedoraproject.org)|8.43.85.73|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://mirror.us-midwest-1.nexcess.net/fedora/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.raw.xz [following]
--2021-01-26 08:48:02--  https://mirror.us-midwest-1.nexcess.net/fedora/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.raw.xz
Resolving mirror.us-midwest-1.nexcess.net (mirror.us-midwest-1.nexcess.net)... 208.69.120.125
Connecting to mirror.us-midwest-1.nexcess.net (mirror.us-midwest-1.nexcess.net)|208.69.120.125|:443... connected.
ERROR: The certificate of ‘mirror.us-midwest-1.nexcess.net’ is not trusted.
ERROR: The certificate of ‘mirror.us-midwest-1.nexcess.net’ has expired.
~~~

Then, it was modified for using the option `--no-dns-cache` like this for skipping the error:

~~~
 $ wget --no-dns-cache https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.raw.xz
~~~


- Updated all the references
 - from fc-31to fc-33
 - from fc31 to fc-33
 - from Fedora 31 to Fedora 33