### PR TITLE
Update validation.md

### DIFF
--- a/docs/workshop/content/validation.md
+++ b/docs/workshop/content/validation.md
@@ -118,9 +118,6 @@ You should be able to open up the application in the same browser that you're re
 Now, if you can tear yourself away from the game, let's actually start working with OpenShift virtualisation, first let's just clean up the default project...
 
 ~~~bash
-$ oc delete dc/duckhunt-js bc/duckhunt-js svc/duckhunt-js route/duckhunt-js
-deploymentconfig.apps.openshift.io "duckhunt-js" deleted                                                                                                                                           
-buildconfig.build.openshift.io "duckhunt-js" deleted                                                                                                                                               
-service "duckhunt-js" deleted
-route.route.openshift.io "duckhunt-js" deleted
+$ oc delete project test-connectiviy
+project.project.openshift.io "test-connectiviy" deleted
 ~~~


### PR DESCRIPTION
The commands for deleting the duckhunt dc and bc gives an error, at least in OCP 4.6

~~~
$ oc delete dc/duckhunt-js bc/duckhunt-js svc/duckhunt-js route/duckhunt-js
service "duckhunt-js" deleted
route.route.openshift.io "duckhunt-js" deleted
Error from server (NotFound): deploymentconfigs.apps.openshift.io "duckhunt-js" not found
Error from server (NotFound): buildconfigs.build.openshift.io "duckhunt-js" not found
~~~

They are `deployment.apps` instead of dc and the buildconfig doesn't exist since it's working with replicaset. 

~~~
$ oc get all
(...) 
NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/duckhunt-js   1/1     1            1           38m

NAME                                     DESIRED   CURRENT   READY   AGE
replicaset.apps/duckhunt-js-5868f66545   0         0         0       38m
replicaset.apps/duckhunt-js-86676b988d   1         1         1       37m
~~~

Then, since it was done a PR [1] for not using the default namespace, It could be deleted the entire project for cleaning the environment. This is the change proposed.

[1] https://github.com/rdoxenham/openshift-virt-labs/pull/7