### PR TITLE
Changed useNamingPrefix to be a boolean instead of one string

### DIFF
--- a/docs/workshop/content/storage-setup.md
+++ b/docs/workshop/content/storage-setup.md
@@ -102,9 +102,9 @@ Now let's create a new NFS-based Peristent Volume Claim (PVC).
 
 For this volume claim we will use a special annotation `cdi.kubevirt.io/storage.import.endpoint` which utilises the Kubernetes Containerized Data Importer (CDI). 
 
-> **NOTE**: CDI is a utility to import, upload, and clone virtual machine images for OpenShift virtualisation. The CDI controller watches for this annotation on the PVC and if found it starts a process to import, upload, or clone. When the annotation is detected the `CDI` controller starts a pod which imports the image from that URL. Cloning and uploading follow a similar process. Read more about the Containerised Data Importer [here](https://kubevirt.io/2018/containerized-data-importer.html).
+> **NOTE**: CDI is a utility to import, upload, and clone virtual machine images for OpenShift virtualisation. The CDI controller watches for this annotation on the PVC and if found it starts a process to import, upload, or clone. When the annotation is detected the `CDI` controller starts a pod which imports the image from that URL. Cloning and uploading follow a similar process. Read more about the Containerised Data Importer [here](https://github.com/kubevirt/containerized-data-importer).
 
-Basically we are askng OpenShift to create this PVC and use the image in the endpoint to fill it. In this case we use `"http://192.168.123.100:81/rhel8-kvm.img"` in the annotation to ensure that upon instantiation of the PV it is populated with the contents of our specific RHEL8 KVM image.
+Basically we are asking OpenShift to create this PVC and use the image in the endpoint to fill it. In this case we use `"http://192.168.123.100:81/rhel8-kvm.img"` in the annotation to ensure that upon instantiation of the PV it is populated with the contents of our specific RHEL8 KVM image.
 
 In addition to triggering the CDI utility we also specify the storage class we created earlier (`nfs`) which is setting the `kubernetes.io/no-provisioner` type as described. Finally note the `requests` section. We are asking for a 40gb volume size which we ensured were available previously via nfs-pv1 and nfs-pv2.
 
@@ -196,7 +196,7 @@ Volumes:
 (...)
 ~~~
 
-Here we can see the importer settings we requested through our claims, such as `IMPORTER_SOURCE`, `IMPORTER_ENDPOINT`, and`IMPORTER_IMAGE_SIZE`. 
+Here we can see the importer settings we requested through our claims, such as `IMPORTER_SOURCE`, `IMPORTER_ENDPOINT`, and `IMPORTER_IMAGE_SIZE`. 
 
 Once this process has completed you'll notice that your PVC is ready to use:
 
@@ -345,7 +345,7 @@ spec:
   imagePullPolicy: IfNotPresent
   pathConfig:
     path: "/var/hpvolumes"
-    useNamingPrefix: "false"
+    useNamingPrefix: false
 EOF
 
 hostpathprovisioner.hostpathprovisioner.kubevirt.io/hostpath-provisioner created


### PR DESCRIPTION
In example for creating the resource HostPathProvisioner:
~~~
$ cat << EOF | oc apply -f -
apiVersion: hostpathprovisioner.kubevirt.io/v1alpha1
kind: HostPathProvisioner
metadata:
  name: hostpath-provisioner
spec:
  imagePullPolicy: IfNotPresent
  pathConfig:
    path: "/var/hpvolumes"
    useNamingPrefix: "false"
EOF
~~~

If this example is used, then, it's possible to see that nothing happens being possible to observe in the hostpath-provisioner-operator-pod the next error:

~~~
$ oc logs <hostpath-provisioner-operator-pod> -n openshift-cnv
(...)
E0412 15:23:17.834894       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:224: Failed to list *v1be
ta1.HostPathProvisioner: v1beta1.HostPathProvisionerList.Items: []v1beta1.HostPathProvisioner: v1beta1.HostPathProvisioner.Spec: v1beta1.Hos
tPathProvisionerSpec.PathConfig: v1beta1.PathConfig.UseNamingPrefix: ReadBool: expect t or f, but found ", error found in #10 byte of ...|gP
refix":"false"}}}]|..., bigger context ...|nfig":{"path":"/var/hpvolumes","useNamingPrefix":"false"}}}],"kind":"HostPathProvisionerList","me
tad|...
E0412 15:23:39.331764       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:224: Failed to list *v1be
ta1.HostPathProvisioner: v1beta1.HostPathProvisionerList.Items: []v1beta1.HostPathProvisioner: v1beta1.HostPathProvisioner.Spec: v1beta1.Hos
tPathProvisionerSpec.PathConfig: v1beta1.PathConfig.UseNamingPrefix: ReadBool: expect t or f, but found ", error found in #10 byte of ...|gP
refix":"false"}}}]|..., bigger context ...|nfig":{"path":"/var/hpvolumes","useNamingPrefix":"false"}}}],"kind":"HostPathProvisionerList","me
tad|...
(...)
~~~

This is indicating that the `UseNamingPrefix` value must be a Boolean and not a String, then, the valid config is:

~~~
$ cat << EOF | oc apply -f -
apiVersion: hostpathprovisioner.kubevirt.io/v1alpha1
kind: HostPathProvisioner
metadata:
  name: hostpath-provisioner
spec:
  imagePullPolicy: IfNotPresent
  pathConfig:
    path: "/var/hpvolumes"
    useNamingPrefix: false
EOF
~~~

At the same time, two little changes more:

- the URL to the Documentation was changed since it's too old (2018) and now it's to the GitHub operator doc
- a little typo fixed in a word
